### PR TITLE
Add sh module version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='phigaro',
               'phigaro = phigaro.cli.batch:main',
               'phigaro-setup = phigaro.cli.helper:main',
           ]
-      }, install_requires=['six', 'sh', 'singleton', 'PyYAML', 'future']
+      }, install_requires=['six', 'sh>=1.12.14', 'singleton', 'PyYAML', 'future']
       )

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='phigaro',
               'phigaro = phigaro.cli.batch:main',
               'phigaro-setup = phigaro.cli.helper:main',
           ]
-      }, install_requires=['six', 'sh>=1.12.14', 'singleton', 'PyYAML', 'future']
+      }, install_requires=['six', 'sh>=1.12.0', 'singleton', 'PyYAML', 'future']
       )


### PR DESCRIPTION
`sh.contrib` is called in [helper.py](https://github.com/lpenguin/phigaro/blob/master/phigaro/helper.py#L86), but version 1.11 of the `sh` module does not have this method. For example, there is no `contrib` [here](https://github.com/amoffat/sh/blob/1.11/sh.py), but there is [here](https://github.com/amoffat/sh/blob/1.12.0/sh.py).

So I have updated the requirement to version 1.12.0. I haven't yet got Phigaro installed yet so please do test it works before merging, thank you!