### PR TITLE
handel absent MetaGeneMark mod files

### DIFF
--- a/phigaro/helper.py
+++ b/phigaro/helper.py
@@ -24,6 +24,12 @@ class MetaGeneMarkKeyNotFound(HelperException):
               "You can download the \"key\" file only. "
 
 
+class MetaGeneMarkModNotFound(HelperException):
+    message = "Please ensure your MetaGeneMark mod file is in the same location as MetaGeneMark: " + \
+              "http://topaz.gatech.edu/GeneMark/license_download.cgi . " + \
+              "You can download the \"mod\" file only. "
+
+
 class HMMERNotFound(HelperException):
     message = "No HMMER found. Please download HMMER package from here: http://hmmer.org/download.html "
 
@@ -114,9 +120,10 @@ class SetupHelper(object):
         )
 
     def _find_mgm_mod_file(self, mgm_dir):
-        # TODO: handle no or multiple .mod files in mgm_dir
         message = 'Please select appropriate MetaGeneMark .mod file location'
         res = glob(join(mgm_dir, '*.mod'))
+        if not res:
+            raise MetaGeneMarkModNotFound()
         return _choose_option(message=message,
                               options=res)
 


### PR DESCRIPTION
[`phigaro/helper.py`](https://github.com/chris-rands/phigaro/blob/master/phigaro/helper.py#L117) includes a note to `# TODO: handle no or multiple .mod files in mgm_dir`. Since I encountered this issue directly, I added simple handling for this, hopefully in line with style used in the rest of the script. Note that I added a way to handel absent `.mod` files only. In fact, I think multiple `.mod` files were already handled correctly in the `_choose_option` function. Please do review and merge if you are happy or suggest further edits otherwise, thank you!