### PR TITLE
Confirm before overwriting existing pvog files

### DIFF
--- a/phigaro/helper.py
+++ b/phigaro/helper.py
@@ -59,6 +59,18 @@ def download_pvogs(base_url, out_dir):
     def download_file(filename):
         url = urljoin(base_url, filename)
         out = join(out_dir, filename)
+        if exists(out):
+            while True:
+                overwrite = input('File {} already exists, overwrite it (Y/N)?'.format(out))
+                if overwrite.upper() in {'Y', 'YES'}:
+                    overwrite = 'Y'
+                    break
+                elif overwrite.upper() in {'N', 'NO'}:
+                    overwrite = 'N'
+                    break
+            if overwrite == 'N':
+                return
+
         print('Downloading {url} to {out}'.format(
             url=url,
             out=out,

--- a/phigaro/helper.py
+++ b/phigaro/helper.py
@@ -42,7 +42,7 @@ def _choose_option(message, options):
 
         for i, option in enumerate(options):
             print("[{}] {}".format(i + 1, option))
-        option_num = str(input('Choose your option (Enter for {}): '.format(options[0])))
+        option_num = input('Choose your option (Enter for {}): '.format(options[0]))
         if option_num == '':
             option_num = '1'
         if re.match(r'^\d+$', option_num):


### PR DESCRIPTION
Downloading the pvog files can take some time, and if they are already downloaded, I thought it might be worth allowing the user to confirm before re-downloading and overwriting. I suggest a simple implementation, let me know what you think, thank you!

Also, very minor edit, but `builtins.input()` always `return`s a string (like `input()` in Python 3), so I removed the unnecessary call.